### PR TITLE
Made GifDrawable class public

### DIFF
--- a/src/pl/droidsonroids/gif/GifDrawable.java
+++ b/src/pl/droidsonroids/gif/GifDrawable.java
@@ -21,7 +21,7 @@ import android.graphics.drawable.Drawable;
  * Basic GIF metadata can be also obtained.  
  * @author koral--
  */
-class GifDrawable extends Drawable implements Animatable
+public class GifDrawable extends Drawable implements Animatable
 {
 	static
 	{


### PR DESCRIPTION
GifDrawable is important for users of the library to have access to.
GifImageView only allows you to set a gif from a resource. GifDrawable
allows the user to set a gif from many different sources.
