### PR TITLE
fix(build.gradle) add some architecture flavors with ndk.abiFilter(s)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,30 @@ android {
         }
     }
     //buildTypes.debug.jniDebuggable true
+
+    productFlavors {
+        x86 {
+            ndk {
+                abiFilter "x86"
+            }
+        }
+        mips {
+            ndk {
+                abiFilter "mips"
+            }
+        }
+        armv7 {
+            ndk {
+                abiFilter "armeabi-v7a"
+            }
+        }
+        arm {
+            ndk {
+                abiFilter "armeabi"
+            }
+        }
+        fat
+    }
 }
 
 


### PR DESCRIPTION
Build one APK per architecture really easily, by using abiFilter property.
This change is needed to integrate native libraries in package and generate APKs for different architectures while correctly handling version codes.
Also without this gradle might fail the build with error similar to error below:
> Error:Execution failed for task ':compileDebugNdk'.
NDK not configured.
  Download the NDK from http://developer.android.com/tools/sdk/ndk/. Then add ndk.dir=path/to/ndk in local.properties.
  (On Windows, make sure you escape backslashes, e.g. C:\\ndk rather than C:\ndk)

even if NDK path configured correctly.