### PR TITLE
Performance and Battery saving improvements in GifDrawable

### DIFF
--- a/src/main/java/pl/droidsonroids/gif/GifDrawable.java
+++ b/src/main/java/pl/droidsonroids/gif/GifDrawable.java
@@ -21,6 +21,7 @@ import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.StrictMode;
+import android.os.SystemClock;
 import android.widget.MediaController.MediaPlayerControl;
 
 import java.io.File;
@@ -44,7 +45,7 @@ public class GifDrawable extends Drawable implements Animatable, MediaPlayerCont
 
     volatile boolean mIsRunning = true;
     private final long mInputSourceLength;
-    long nextFrameRenderTime = System.currentTimeMillis();
+    long nextFrameRenderTime = SystemClock.elapsedRealtime();
 
     private final Rect mDstRect = new Rect();
     /**
@@ -643,7 +644,7 @@ public class GifDrawable extends Drawable implements Animatable, MediaPlayerCont
             mPaint.setColorFilter(null);
         }
 
-        int invalidationDelay = (int)Math.max(0, this.nextFrameRenderTime - System.currentTimeMillis());
+        int invalidationDelay = (int)Math.max(0, this.nextFrameRenderTime - SystemClock.elapsedRealtime());
         mExecutor.schedule(mRenderTask, invalidationDelay, TimeUnit.MILLISECONDS);
     }
 

--- a/src/main/java/pl/droidsonroids/gif/GifDrawable.java
+++ b/src/main/java/pl/droidsonroids/gif/GifDrawable.java
@@ -31,6 +31,7 @@ import java.nio.ByteBuffer;
 import java.util.Locale;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
 
 /**
  * A {@link Drawable} which can be used to hold GIF images, especially animations.
@@ -43,6 +44,7 @@ public class GifDrawable extends Drawable implements Animatable, MediaPlayerCont
 
     volatile boolean mIsRunning = true;
     private final long mInputSourceLength;
+    long nextFrameRenderTime = System.currentTimeMillis();
 
     private final Rect mDstRect = new Rect();
     /**
@@ -640,6 +642,9 @@ public class GifDrawable extends Drawable implements Animatable, MediaPlayerCont
         if (clearColorFilter) {
             mPaint.setColorFilter(null);
         }
+
+        int invalidationDelay = (int)Math.max(0, this.nextFrameRenderTime - System.currentTimeMillis());
+        mExecutor.schedule(mRenderTask, invalidationDelay, TimeUnit.MILLISECONDS);
     }
 
     /**

--- a/src/main/java/pl/droidsonroids/gif/RenderTask.java
+++ b/src/main/java/pl/droidsonroids/gif/RenderTask.java
@@ -20,15 +20,15 @@ class RenderTask extends SafeRunnable {
     public void doWork() {
         final long renderResult = mGifDrawable.mNativeInfoHandle.renderFrame(mGifDrawable.mBuffer);
         final int invalidationDelay = (int) (renderResult >> 1);
+        mGifDrawable.nextFrameRenderTime = System.currentTimeMillis() + invalidationDelay;
         if ((int) (renderResult & 1L) == 1 && !mGifDrawable.mListeners.isEmpty()) {
             mGifDrawable.scheduleSelf(mNotifyListenersTask, 0L);
         }
         if (invalidationDelay >= 0) {
             if (mGifDrawable.isVisible() && mGifDrawable.mIsRunning) {
-                mGifDrawable.mExecutor.schedule(this, invalidationDelay, TimeUnit.MILLISECONDS);
+                mGifDrawable.unscheduleSelf(mGifDrawable.mInvalidateTask);
+                mGifDrawable.scheduleSelf(mGifDrawable.mInvalidateTask, 0L);
             }
-            mGifDrawable.unscheduleSelf(mGifDrawable.mInvalidateTask);
-            mGifDrawable.scheduleSelf(mGifDrawable.mInvalidateTask, 0L);
         }
     }
 }

--- a/src/main/java/pl/droidsonroids/gif/RenderTask.java
+++ b/src/main/java/pl/droidsonroids/gif/RenderTask.java
@@ -1,6 +1,6 @@
 package pl.droidsonroids.gif;
 
-import java.util.concurrent.TimeUnit;
+import android.os.SystemClock;
 
 class RenderTask extends SafeRunnable {
 
@@ -20,7 +20,7 @@ class RenderTask extends SafeRunnable {
     public void doWork() {
         final long renderResult = mGifDrawable.mNativeInfoHandle.renderFrame(mGifDrawable.mBuffer);
         final int invalidationDelay = (int) (renderResult >> 1);
-        mGifDrawable.nextFrameRenderTime = System.currentTimeMillis() + invalidationDelay;
+        mGifDrawable.nextFrameRenderTime = SystemClock.elapsedRealtime() + invalidationDelay;
         if ((int) (renderResult & 1L) == 1 && !mGifDrawable.mListeners.isEmpty()) {
             mGifDrawable.scheduleSelf(mNotifyListenersTask, 0L);
         }


### PR DESCRIPTION
Do not schedule the render of the next frame until the current frame is
drawn.
Advantages:
1. Pre-api 14 there is no good way to know when the app is going to the
background and therefore, no way to pause animations from running while
in background and then we get the rendering task being scheduled over
and over again when nothing is drawn - with this fix, rendering of next
frame is dependant on drawing of previous one, so when going to
background all animations pause since nothing is drawn and they resume
when the app comes back
2. It is virtually impossible to manage visibility for every single Gif
and make sure to pause it when not visible (especially if the gif is not
in a view, but in something like a span) - when the next frame is
dependent on drawing the frame before then while the animation is not
visible, it is paused automatically since it is not drawn
3. We save CPU time by not rendering frames that will not be displayed.
When the rendering of next frame is dependant on drawing of previous
ones we render exactly as many frames as are actually displayed, saving
CPU