### PR TITLE
Implemented glTexSubImage2D()

### DIFF
--- a/src/main/java/pl/droidsonroids/gif/GifInfoHandle.java
+++ b/src/main/java/pl/droidsonroids/gif/GifInfoHandle.java
@@ -143,6 +143,8 @@ final class GifInfoHandle {
 
 	private static native void glTexImage2D(long gifInfoPtr);
 
+	private static native void glTexSubImage2D(long gifInfoPtr);
+
 	private static native void seekToFrameGL(long gifInfoPtr, int index);
 
 	private static native void initTexImageDescriptor(long gifInfoPtr);
@@ -293,6 +295,10 @@ final class GifInfoHandle {
 
 	void glTexImage2D() {
 		glTexImage2D(gifInfoPtr);
+	}
+
+	void glTexSubImage2D() {
+		glTexSubImage2D(gifInfoPtr);
 	}
 
 	void startDecoderThread() {

--- a/src/main/java/pl/droidsonroids/gif/GifTexImage2D.java
+++ b/src/main/java/pl/droidsonroids/gif/GifTexImage2D.java
@@ -67,10 +67,17 @@ public class GifTexImage2D {
 	/**
 	 * Equivalent of {@link android.opengl.GLES20#glTexImage2D(int, int, int, int, int, int, int, int, Buffer)}.
 	 * Where <code>target</code> is {@link android.opengl.GLES20#GL_TEXTURE_2D} and <code>Buffer</code> contains pixels of the current frame.
-	 * Does nothing if decoder thread is not started.
 	 */
 	public void glTexImage2D() {
 		mGifInfoHandle.glTexImage2D();
+	}
+
+	/**
+	 * Equivalent of {@link android.opengl.GLES20#glTexSubImage2D(int, int, int, int, int, int, int, int, Buffer)}.
+	 * Where <code>target</code> is {@link android.opengl.GLES20#GL_TEXTURE_2D} and <code>Buffer</code> contains pixels of the current frame.
+	 */
+	public void glTexSubImage2D() {
+		mGifInfoHandle.glTexSubImage2D();
 	}
 
 	/**

--- a/src/main/jni/opengl.c
+++ b/src/main/jni/opengl.c
@@ -21,6 +21,20 @@ Java_pl_droidsonroids_gif_GifInfoHandle_glTexImage2D(JNIEnv *__unused unused, jc
 	             texImageDescriptor->frameBuffer);
 }
 
+__unused JNIEXPORT void JNICALL
+Java_pl_droidsonroids_gif_GifInfoHandle_glTexSubImage2D(JNIEnv *__unused unused, jclass __unused handleClass,
+                                                     jlong gifInfo) {
+	GifInfo *info = (GifInfo *) gifInfo;
+	if (info == NULL || info->frameBufferDescriptor == NULL) {
+		return;
+	}
+	const TexImageDescriptor *texImageDescriptor = info->frameBufferDescriptor;
+	const GLsizei width = (const GLsizei) info->gifFilePtr->SWidth;
+	const GLsizei height = (const GLsizei) info->gifFilePtr->SHeight;
+	glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, width, height, GL_RGBA, GL_UNSIGNED_BYTE,
+	             texImageDescriptor->frameBuffer);
+}
+
 static void *slurp(void *pVoidInfo) {
 	GifInfo *info = pVoidInfo;
 	while (1) {


### PR DESCRIPTION
This call might be optimized when #287 is implemented (by performing dirty region only updates). It's also pretty clear now that there are 2 separate calls that 80% of work is done by the seekframe() call so worth thinking about a caching option too.