### PR TITLE
fix loopCount

### DIFF
--- a/android-gif-drawable/src/main/c/decoding.c
+++ b/android-gif-drawable/src/main/c/decoding.c
@@ -175,7 +175,11 @@ static int readExtensions(int ExtFunction, GifByteType *ExtData, GifInfo *info) 
 				return GIF_ERROR;
 			}
 			if (ExtData[0] == 3 && ExtData[1] == 1) {
-				info->loopCount = (uint_fast16_t) (ExtData[2] + (ExtData[3] << 8));
+				uint_fast16_t loopCount = (uint_fast16_t) (ExtData[2] + (ExtData[3] << 8));
+				if (loopCount) {
+					loopCount++;
+				}
+				info->loopCount = loopCount;
 			}
 		}
 	}


### PR DESCRIPTION
Value 0 in "NETSCAPE2.0" means loop forever.
Missing "NETSCAPE2.0" block means 0 repetitions = loop once.
Value 1 in "NETSCAPE2.0" means 1 repetition = 2 loops.
Value 2 in "NETSCAPE2.0" means 2 repetitions = 3 loops.

https://bugs.chromium.org/p/chromium/issues/detail?id=592735
https://bugzilla.mozilla.org/show_bug.cgi?id=1255497