### PR TITLE
Change the method name 'build' to 'createGifDrawable', 'with' to 'setOldDrawable'

### DIFF
--- a/android-gif-drawable/src/main/java/pl/droidsonroids/gif/GifAnimationMetaData.java
+++ b/android-gif-drawable/src/main/java/pl/droidsonroids/gif/GifAnimationMetaData.java
@@ -221,7 +221,7 @@ public class GifAnimationMetaData implements Serializable, Parcelable {
 
 	/**
 	 * Like {@link GifDrawable#getAllocationByteCount()} but does not include memory needed for backing {@link android.graphics.Bitmap}.
-	 * {@code Bitmap} in {@code GifDrawable} may be allocated at the time of creation or existing one may be reused if {@link GifDrawableInit#setOldDrawable(GifDrawable)}
+	 * {@code Bitmap} in {@code GifDrawable} may be allocated at the time of creation or existing one may be reused if {@link GifDrawableInit#with(GifDrawable)}
 	 * is used.
 	 * This method assumes no subsampling (sample size = 1).<br>
 	 * To calculate allocation byte count of {@link GifDrawable} created from the same input source {@link #getDrawableAllocationByteCount(GifDrawable, int)}

--- a/android-gif-drawable/src/main/java/pl/droidsonroids/gif/GifAnimationMetaData.java
+++ b/android-gif-drawable/src/main/java/pl/droidsonroids/gif/GifAnimationMetaData.java
@@ -221,7 +221,7 @@ public class GifAnimationMetaData implements Serializable, Parcelable {
 
 	/**
 	 * Like {@link GifDrawable#getAllocationByteCount()} but does not include memory needed for backing {@link android.graphics.Bitmap}.
-	 * {@code Bitmap} in {@code GifDrawable} may be allocated at the time of creation or existing one may be reused if {@link GifDrawableBuilder#with(GifDrawable)}
+	 * {@code Bitmap} in {@code GifDrawable} may be allocated at the time of creation or existing one may be reused if {@link GifDrawableInit#setOldDrawable(GifDrawable)}
 	 * is used.
 	 * This method assumes no subsampling (sample size = 1).<br>
 	 * To calculate allocation byte count of {@link GifDrawable} created from the same input source {@link #getDrawableAllocationByteCount(GifDrawable, int)}

--- a/android-gif-drawable/src/main/java/pl/droidsonroids/gif/GifDrawableInit.java
+++ b/android-gif-drawable/src/main/java/pl/droidsonroids/gif/GifDrawableInit.java
@@ -61,7 +61,7 @@ public abstract class GifDrawableInit<T extends GifDrawableInit<T>> {
         if (mInputSource == null) {
             throw new NullPointerException("Source is not set");
         }
-        return mInputSource.build(mOldDrawable, mExecutor, mIsRenderingTriggeredOnDraw, mOptions);
+        return mInputSource.createGifDrawable(mOldDrawable, mExecutor, mIsRenderingTriggeredOnDraw, mOptions);
     }
 
     /**

--- a/android-gif-drawable/src/main/java/pl/droidsonroids/gif/GifDrawableInit.java
+++ b/android-gif-drawable/src/main/java/pl/droidsonroids/gif/GifDrawableInit.java
@@ -70,7 +70,7 @@ public abstract class GifDrawableInit<T extends GifDrawableInit<T>> {
      * @param drawable drawable to be reused
      * @return this builder instance, to chain calls
      */
-    public T with(GifDrawable drawable) {
+    public T setOldDrawable(GifDrawable drawable) {
         mOldDrawable = drawable;
         return self();
     }

--- a/android-gif-drawable/src/main/java/pl/droidsonroids/gif/GifDrawableInit.java
+++ b/android-gif-drawable/src/main/java/pl/droidsonroids/gif/GifDrawableInit.java
@@ -70,7 +70,7 @@ public abstract class GifDrawableInit<T extends GifDrawableInit<T>> {
      * @param drawable drawable to be reused
      * @return this builder instance, to chain calls
      */
-    public T setOldDrawable(GifDrawable drawable) {
+    public T with(GifDrawable drawable) {
         mOldDrawable = drawable;
         return self();
     }

--- a/android-gif-drawable/src/main/java/pl/droidsonroids/gif/InputSource.java
+++ b/android-gif-drawable/src/main/java/pl/droidsonroids/gif/InputSource.java
@@ -27,8 +27,8 @@ public abstract class InputSource {
 
 	abstract GifInfoHandle open() throws IOException;
 
-	final GifDrawable build(final GifDrawable oldDrawable, final ScheduledThreadPoolExecutor executor,
-	                        final boolean isRenderingAlwaysEnabled, final GifOptions options) throws IOException {
+	final GifDrawable createGifDrawable(final GifDrawable oldDrawable, final ScheduledThreadPoolExecutor executor,
+										final boolean isRenderingAlwaysEnabled, final GifOptions options) throws IOException {
 
 		return new GifDrawable(createHandleWith(options), oldDrawable, executor, isRenderingAlwaysEnabled);
 	}


### PR DESCRIPTION
The class 'InputSource' is used to handle Input Source. This method named 'build' is to create a new gif drawable from an input source. Thus, the method name 'createGifDrawable' is more intuitive than 'build'.

This class GifDrawableInit is used to init GifDrawable.  This method named 'with' is to set old drawable object. Thus, the method name 'setOldDrawable' is more intuitive than 'with'.