### PR TITLE
Double free problem

### DIFF
--- a/android-gif-drawable/src/main/c/decoding.c
+++ b/android-gif-drawable/src/main/c/decoding.c
@@ -56,9 +56,15 @@ void DDGifSlurp(GifInfo *info, bool decode, bool exitAfterFrame) {
 				}
 
 				if (decode) {
-					int_fast32_t widthOverflow = gifFilePtr->Image.Width - info->originalWidth;
-					int_fast32_t heightOverflow = gifFilePtr->Image.Height - info->originalHeight;
 					const uint_fast32_t newRasterSize = gifFilePtr->Image.Width * gifFilePtr->Image.Height;
+					if (newRasterSize == 0) {
+						free(info->rasterBits);
+						info->rasterBits = NULL;
+						info->rasterSize = newRasterSize;
+						return;
+					}
+					const int_fast32_t widthOverflow = gifFilePtr->Image.Width - info->originalWidth;
+					const int_fast32_t heightOverflow = gifFilePtr->Image.Height - info->originalHeight;
 					if (newRasterSize > info->rasterSize || widthOverflow > 0 || heightOverflow > 0) {
 						void *tmpRasterBits = reallocarray(info->rasterBits, newRasterSize, sizeof(GifPixelType));
 						if (tmpRasterBits == NULL) {

--- a/android-gif-drawable/src/main/c/gif.h
+++ b/android-gif-drawable/src/main/c/gif.h
@@ -31,6 +31,8 @@
 #include <android/log.h>
 #define  LOG_TAG    "libgif"
 #define  LOGE(...)  __android_log_print(ANDROID_LOG_ERROR,LOG_TAG,__VA_ARGS__)
+#else
+#define  LOGE(...)
 #endif
 
 #define THROW_ON_NONZERO_RESULT(fun, message) if ((fun) !=0) throwException(env, RUNTIME_EXCEPTION_ERRNO, message)


### PR DESCRIPTION
If a gif has at least three frames, first with non-zero size and two others with 0 size then the lib may free one pointer twice.

I'm not sure if I've correctly understood the code but it looks like it is enough to just free rasterBits and nullify them in case of empty frame.

Also I've defined LOGE() macro for release (as NOOP) to avoid `#ifdef DEBUG` every time I need to use logging ;)

The version of problematic gif added (since it is rather strange gif I've zipped it to avoid possible problems with its playback.
[exploit.zip](https://github.com/koral--/android-gif-drawable/files/3488625/exploit.zip)