### PR TITLE
Outbound read

### DIFF
--- a/android-gif-drawable/src/main/c/decoding.c
+++ b/android-gif-drawable/src/main/c/decoding.c
@@ -30,6 +30,11 @@ void DDGifSlurp(GifInfo *info, bool decode, bool exitAfterFrame) {
 			case IMAGE_DESC_RECORD_TYPE:
 
 				if (DGifGetImageDesc(gifFilePtr, isInitialPass) == GIF_ERROR) {
+					if (info->rasterBits != NULL) {
+						free(info->rasterBits);
+						info->rasterBits = NULL;
+					}
+					info->rasterSize = 0;
 					break;
 				}
 

--- a/android-gif-drawable/src/main/c/init.c
+++ b/android-gif-drawable/src/main/c/init.c
@@ -43,6 +43,8 @@ GifInfo *createGifInfo(GifSourceDescriptor *descriptor, JNIEnv *env) {
 	info->isOpaque = false;
 	info->sampleSize = 1;
 
+	info->rasterBits = NULL;
+	info->rasterSize = 0;
 	DDGifSlurp(info, false, false);
 	info->rasterBits = NULL;
 	info->rasterSize = 0;


### PR DESCRIPTION
If we have a gif with at least two frames and one frame is a valid one, but the second one is bigger but malformed in a way the lib fails to read it we may end up with a situation when we have size for the second frame and when drawing we will try to use rasterBits from a previous frame but access bytes outside of the allocated area.  One such gif is attached.
[wa_gif_bug_1.zip](https://github.com/koral--/android-gif-drawable/files/3503300/wa_gif_bug_1.zip)

As a solution I've set rasterBits to NULL to make sure drawing will not work with it.
Also I've noticed that we call DDGifSlurp() from init before setting resterBits to NULL and since now I need to use this field I've fixed this issue too.
Open question: after DDGifSlurp() returns we set rasterBits in init() to NULL, perhaps we should also free the memory.
