### PR TITLE
Fix out of bounds read/write in gif decoding

### DIFF
--- a/android-gif-drawable/src/main/c/giflib/dgif_lib.c
+++ b/android-gif-drawable/src/main/c/giflib/dgif_lib.c
@@ -266,6 +266,12 @@ DGifGetImageDesc(GifFileType *GifFile, bool changeImageCount) {
 		}
 	}
 
+	/* Reset decompress algorithm parameters. */
+	if (DGifSetupDecompress(GifFile) == GIF_ERROR) {
+		// skip frame
+		return GIF_ERROR;
+	}
+
 	if (changeImageCount) {
 		SavedImage *new_saved_images = (SavedImage *) reallocarray(GifFile->SavedImages, GifFile->ImageCount + 1, sizeof(SavedImage));
 		if (new_saved_images == NULL) {
@@ -292,8 +298,7 @@ DGifGetImageDesc(GifFileType *GifFile, bool changeImageCount) {
 	}
 	Private->PixelCount = GifFile->Image.Width * GifFile->Image.Height;
 
-	/* Reset decompress algorithm parameters. */
-	return DGifSetupDecompress(GifFile);
+	return GIF_OK;
 }
 
 /******************************************************************************


### PR DESCRIPTION
To trigger the bug, the GIF file is required to have at least two frames, with the second frame having a malformed image descriptor, and a larger height/width than the first frame.

The malformed image descriptor causes the parsing to fail prematurely, which in turn causes the rasterBits array to not be reallocated with the second frame's size.

When the library attempts to render the second frame, it will read from the rasterBits array using the height and width of the second frame, and trigger the bug.

---

Changing the order of operations within DGifGetImageDesc so that we can
discard bad image blocks and continue gracefully.

Prior to this change, the bad image was still read into SavedImages,
leading to a inconsistency in image size metadata in SavedImage vs
GifFileType. This causes potential read/write out of bounds that may
cause app crashes.