### PR TITLE
Fix buffer size allocation with malformed gifs

### DIFF
--- a/android-gif-drawable/src/main/c/decoding.c
+++ b/android-gif-drawable/src/main/c/decoding.c
@@ -39,22 +39,6 @@ void DDGifSlurp(GifInfo *info, bool decode, bool exitAfterFrame) {
 				}
 
 				if (isInitialPass) {
-					int_fast32_t widthOverflow = gifFilePtr->Image.Width - gifFilePtr->SWidth;
-					int_fast32_t heightOverflow = gifFilePtr->Image.Height - gifFilePtr->SHeight;
-					if (widthOverflow > 0 || heightOverflow > 0) {
-						gifFilePtr->SWidth += widthOverflow;
-						gifFilePtr->SHeight += heightOverflow;
-					}
-					SavedImage *sp = &gifFilePtr->SavedImages[gifFilePtr->ImageCount - 1];
-					int_fast32_t topOverflow = gifFilePtr->Image.Top + gifFilePtr->Image.Height - gifFilePtr->SHeight;
-					if (topOverflow > 0) {
-						sp->ImageDesc.Top -= topOverflow;
-					}
-
-					int_fast32_t leftOverflow = gifFilePtr->Image.Left + gifFilePtr->Image.Width - gifFilePtr->SWidth;
-					if (leftOverflow > 0) {
-						sp->ImageDesc.Left -= leftOverflow;
-					}
 					if (!updateGCB(info, &lastAllocatedGCBIndex)) {
 						break;
 					}

--- a/android-gif-drawable/src/main/c/giflib/dgif_lib.c
+++ b/android-gif-drawable/src/main/c/giflib/dgif_lib.c
@@ -235,6 +235,11 @@ DGifGetImageDesc(GifFileType *GifFile, bool changeImageCount) {
 		GifFile->Image.ColorMap = NULL;
 		return GIF_ERROR;
 	}
+	// Error out if any part of the image is outside the logical screen
+	if (GifFile->Image.Left + GifFile->Image.Width > GifFile->SWidth ||
+		GifFile->Image.Top + GifFile->Image.Height > GifFile->SHeight) {
+		return GIF_ERROR;
+	}
 	uint_fast8_t BitsPerPixel = (uint_fast8_t) ((Buf[0] & 0x07) + 1);
 	GifFile->Image.Interlace = (Buf[0] & 0x40) ? true : false;
 


### PR DESCRIPTION
If either widthOverflow or heightOverflow were negative and the other was positive, this would result in adding a negative number to gifFilePtr's dimensions and therefore make us allocate too small of a buffer resulting in an OOB write heap overflow.

Instead of calculating an image's overflow and attempting to adjust the canvas size so the largest image inside the gif would be able fit in our buffer, just return an error and quit trying.

This makes the handling of this undefined behavior more similar to other implementations (Firefox, Chrome, Preview, etc) which simply skip drawing the frame. 