### PR TITLE
Use dup instead of fcntl to duplicate file descriptor

### DIFF
--- a/android-gif-drawable/gradle.properties
+++ b/android-gif-drawable/gradle.properties
@@ -1,4 +1,4 @@
-VERSION_NAME=1.2.19
+VERSION_NAME=1.2.20-SNAPSHOT
 GROUP=pl.droidsonroids.gif
 
 POM_DESCRIPTION=Views and Drawable for displaying animated GIFs for Android

--- a/android-gif-drawable/src/main/c/gif.c
+++ b/android-gif-drawable/src/main/c/gif.c
@@ -323,7 +323,7 @@ Java_pl_droidsonroids_gif_GifInfoHandle_extractNativeFileDescriptor(JNIEnv *env,
 		return -1;
 	}
 	const jint oldFd = (*env)->GetIntField(env, fileDescriptor, fdClassDescriptorFieldID);
-	const int fd = fcntl(oldFd, F_DUPFD_CLOEXEC, 0);
+    const int fd = dup(oldFd);
 	if (fd == -1) {
 		throwGifIOException(D_GIF_ERR_OPEN_FAILED, env, true);
 	}


### PR DESCRIPTION
Possible fix for #701.