### PR TITLE
Revert "Let's clear rasterBits if failed to read frame's header." and…

### DIFF
--- a/android-gif-drawable/src/main/c/decoding.c
+++ b/android-gif-drawable/src/main/c/decoding.c
@@ -30,11 +30,6 @@ void DDGifSlurp(GifInfo *info, bool decode, bool exitAfterFrame) {
 			case IMAGE_DESC_RECORD_TYPE:
 
 				if (DGifGetImageDesc(gifFilePtr, isInitialPass) == GIF_ERROR) {
-					if (info->rasterBits != NULL) {
-						free(info->rasterBits);
-						info->rasterBits = NULL;
-					}
-					info->rasterSize = 0;
 					break;
 				}
 

--- a/android-gif-drawable/src/main/c/drawing.c
+++ b/android-gif-drawable/src/main/c/drawing.c
@@ -18,6 +18,9 @@ static inline void blitNormal(argb *bm, GifInfo *info, SavedImage *frame, ColorM
 	const int_fast16_t transpIndex = info->controlBlock[info->currentIndex].TransparentColor;
 	const GifWord frameWidth = frame->ImageDesc.Width;
 	const GifWord padding = info->stride - frameWidth;
+	if (info->rasterSize < frame->ImageDesc.Height * frame->ImageDesc.Width) {
+		return;
+	}
 	if (info->isOpaque) {
 		if (transpIndex == NO_TRANSPARENT_COLOR) {
 			for (; y > 0; y--) {


### PR DESCRIPTION
… additional safety check in blitNormal

This reverts commit c2a5ff582177454927eb8ef3cb9b5488485372d4.

Deallocating rasterBits and resetting rasterSize can cause a heap
buffer overflow read on malformed GIF inputs.

Frame 0: size 100x100
Frame 1: invalid frame, DGifGetRecordType returns GIF_ERROR
Frame 2: size 10x10

rasterBits will be allocated with size 100, but will be attempted
to be read with Frame 0's dimensions during rendering in blitNormal.

Reverting this commit should not cause a regression since commit
5219e25 prevents the bug that the reverted commit was fixing.

Adding an additional safety check in blitNormal that should be a
catch-all for other undiscovered OOB reads due to mismatching
image metadata.