### PR TITLE
fix bug "Abort message: 'attempted to close file descriptor 165, expe…

### DIFF
--- a/android-gif-drawable/src/main/c/gif.c
+++ b/android-gif-drawable/src/main/c/gif.c
@@ -352,6 +352,7 @@ Java_pl_droidsonroids_gif_GifInfoHandle_openNativeFileDescriptor(JNIEnv *env, jc
 
 		GifInfo *const info = createGifInfoFromFile(env, file, sourceLength);
 		if (info == NULL) {
+			fclose(file);
 			close(fd);
 		}
 		return (jlong) info;


### PR DESCRIPTION
…cted to be unowned, actually owned by FILE* 0xee9042ac'"  call fclose(file) before close(fd) if createGifInofoFromFiile failed