### PR TITLE
[skip ci]Update README to show the latest version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Bundled GIFLib via JNI is used to render frames. This way should be more efficie
 Insert the following dependency to `build.gradle` file of your project.
 ```groovy
 dependencies {
-    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.22'
+    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.23'
 }
 ```
 Note that Maven central repository should be defined eg. in top-level `build.gradle` like this:


### PR DESCRIPTION
From what I can see it looks like 1.2.23 is the latest version of the GIF-drawable. Updated README to show the latest version of GIF drawable.