### PR TITLE
Fix JNI memory-safety bugs and release 1.2.32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+#### 1.2.32
+- 2026-06-18 - [commits](https://github.com/koral--/android-gif-drawable/compare/v1.2.31...v1.2.32)
+- Fix use-after-free reading file size after ReleaseStringUTFChars in openFile, fixes [(#870)](https://github.com/koral--/android-gif-drawable/issues/870), thanks @Fuyugithub for reporting
+- Add missing intptr_t cast in openNativeFileDescriptor return, fixes [(#871)](https://github.com/koral--/android-gif-drawable/issues/871), thanks @Fuyugithub for reporting
+- Fix dangling pointer and leaks on eventfd failure in startDecoderThread, fixes [(#872)](https://github.com/koral--/android-gif-drawable/issues/872), thanks @Fuyugithub for reporting
+
 #### 1.2.31
 - 2026-02-12 - [commits](https://github.com/koral--/android-gif-drawable/compare/v1.2.30...v1.2.31)
 - Remove Kotlin dependency from library module, fixes [(#866)](https://github.com/koral--/android-gif-drawable/issues/866), thanks @beigirad for reporting

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Bundled GIFLib via JNI is used to render frames. This way should be more efficie
 Insert the following dependency to `build.gradle` file of your project.
 ```groovy
 dependencies {
-    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.31'
+    implementation 'pl.droidsonroids.gif:android-gif-drawable:1.2.32'
 }
 ```
 Note that Maven central repository should be defined eg. in top-level `build.gradle` like this:

--- a/android-gif-drawable/src/main/c/gif.c
+++ b/android-gif-drawable/src/main/c/gif.c
@@ -354,7 +354,7 @@ Java_pl_droidsonroids_gif_GifInfoHandle_openNativeFileDescriptor(JNIEnv *env, jc
 		if (info == NULL) {
 			fclose(file);
 		}
-		return (jlong) info;
+		return (jlong) (intptr_t) info;
 	} else {
 		throwGifIOException(D_GIF_ERR_OPEN_FAILED, env, true);
 		close(fd);

--- a/android-gif-drawable/src/main/c/gif.c
+++ b/android-gif-drawable/src/main/c/gif.c
@@ -151,7 +151,7 @@ Java_pl_droidsonroids_gif_GifInfoHandle_openFile(JNIEnv *env, jclass __unused cl
 	(*env)->ReleaseStringUTFChars(env, jfname, filename);
 
 	struct stat64 st;
-	const long long sourceLength = stat64(filename, &st) == 0 ? st.st_size : -1;
+	const long long sourceLength = fstat64(fileno(file), &st) == 0 ? st.st_size : -1;
 
 	GifInfo *const info = createGifInfoFromFile(env, file, sourceLength);
 	if (info == NULL) {

--- a/android-gif-drawable/src/main/c/opengl.c
+++ b/android-gif-drawable/src/main/c/opengl.c
@@ -128,6 +128,9 @@ Java_pl_droidsonroids_gif_GifInfoHandle_startDecoderThread(JNIEnv *env, jclass _
 	texImageDescriptor->eventPollFd.events = POLL_IN;
 	texImageDescriptor->eventPollFd.fd = eventfd(0, 0);
 	if (texImageDescriptor->eventPollFd.fd == -1) {
+		info->frameBufferDescriptor = NULL;
+		free(texImageDescriptor->frameBuffer);
+		pthread_mutex_destroy(&texImageDescriptor->renderMutex);
 		free(texImageDescriptor);
 		throwException(env, RUNTIME_EXCEPTION_ERRNO, "Eventfd creation failed ");
 		return;

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,7 +4,7 @@ android.nonFinalResIds=false
 
 GROUP=pl.droidsonroids.gif
 POM_ARTIFACT_ID=android-gif-drawable
-VERSION_NAME=1.2.31
+VERSION_NAME=1.2.32
 
 POM_NAME=android-gif-drawable
 POM_DESCRIPTION=Views and Drawable for displaying animated GIFs for Android
@@ -20,5 +20,5 @@ POM_SCM_CONNECTION=scm:git:git://github.com/koral--/android-gif-drawable.git
 POM_SCM_DEV_CONNECTION=scm:git:ssh://git@github.com/koral--/android-gif-drawable.git
 
 POM_DEVELOPER_ID=koral
-POM_DEVELOPER_NAME=Karol Wrótniak
+POM_DEVELOPER_NAME=Karol Wrï¿½tniak
 POM_DEVELOPER_URL=https://github.com/koral--


### PR DESCRIPTION
Fixes three memory-safety bugs in the JNI layer reported by @Fuyugithub, and bumps the version to 1.2.32.

## Changes

- **Use-after-free in `openFile`** (`gif.c`): the file size was read with `stat64(filename, ...)` *after* `filename` had already been handed back to the JVM via `ReleaseStringUTFChars`. Now reads the size from the already-open handle with `fstat64(fileno(file), ...)`, matching the idiom in `openNativeFileDescriptor`.
- **Missing `intptr_t` cast in `openNativeFileDescriptor`** (`gif.c`): the return used `(jlong) info` while every other open method goes through `(jlong) (intptr_t) info`. Routed through `intptr_t` for a guaranteed-correct pointer round-trip and consistency.
- **Dangling pointer and leaks in `startDecoderThread`** (`opengl.c`): on `eventfd()` failure the code freed `texImageDescriptor` but left `info->frameBufferDescriptor` pointing at the freed block (a non-NULL dangling pointer later dereferenced by `stopDecoderThread`/`seekToFrameGL`), and leaked `frameBuffer` and `renderMutex`. Now mirrors `releaseTexImageDescriptor`'s cleanup and nulls the field.

## Release

`Release 1.2.32` bumps `gradle.properties`, `README.md`, and `CHANGELOG.md`.

Fixes #870
Fixes #871
Fixes #872

🤖 Generated with [Claude Code](https://claude.com/claude-code)